### PR TITLE
Add SSH Public Key to VM Creation Task

### DIFF
--- a/project/create_rhel_vm_demo.yml
+++ b/project/create_rhel_vm_demo.yml
@@ -103,7 +103,7 @@
 
     - name: Setup public keys
       when: rhel_public_key is defined
-      ansibe.builtin.set_fact:
+      ansible.builtin.set_fact:
         rhel_ssh_public_keys:
           - path: "/home/{{ rhel_admin_user }}/.ssh/authorized_keys"
             key_data: "{{ rhel_public_key }}"

--- a/project/create_rhel_vm_demo.yml
+++ b/project/create_rhel_vm_demo.yml
@@ -101,6 +101,13 @@
         security_group: "{{ network_sec_group_name }}"
       when: survey_public_ip == "True"
 
+    - name: Setup public keys
+      when: rhel_public_key is defined
+      ansibe.builtin.set_fact:
+        rhel_ssh_public_keys:
+          - path: "/home/{{ rhel_admin_user }}/.ssh/authorized_keys"
+            key_data: "{{ rhel_public_key }}"
+
     - name: Create VM
       azure.azcollection.azure_rm_virtualmachine:
         resource_group: "{{ resource_group_name }}"
@@ -111,6 +118,7 @@
         admin_password: "{{ rhel_admin_password }}"
         network_interfaces: "{{ rhel_nic_name }}"
         ssh_password_enabled: true
+        ssh_public_keys: "{{ rhel_ssh_public_keys | default(omit) }}"
         tags:
           "name": "{{ rhel_vm_name }}"
           "demo": "true"


### PR DESCRIPTION
The existing guide instructs you to add your public key to the extra vars of the "Create RHEL VM" job template, but the corresponding playbook was not adding it as user data during VM creation.

I tested the below changes omitting the public key and including it, both scenarios worked as expected.